### PR TITLE
Status code

### DIFF
--- a/openag_module.h
+++ b/openag_module.h
@@ -10,7 +10,7 @@
 static const uint8_t OK = 0;
 static const uint8_t WARN = 1;
 static const uint8_t ERROR = 2;
-static const uint8_t CODE_NONE = 0;
+static const uint8_t CODE_OK = 0;
 
 class Module {
   public:

--- a/openag_module.h
+++ b/openag_module.h
@@ -10,6 +10,7 @@
 static const uint8_t OK = 0;
 static const uint8_t WARN = 1;
 static const uint8_t ERROR = 2;
+static const uint8_t CODE_NONE = 0;
 
 class Module {
   public:
@@ -19,7 +20,7 @@ class Module {
     virtual void update() = 0;
 
     uint8_t status_level;
-    String status_msg;
+    uint8_t status_code;
 };
 
 #endif


### PR DESCRIPTION
Transition from storing status messages in firmware. Instead, send
status codes from firmware. RPi client is responsible for turning status
codes into status messages for ROS /diagnostics.