### PR TITLE
Revert "Naming: CODE_OK -> STATUS_OK"

### DIFF
--- a/openag_module.h
+++ b/openag_module.h
@@ -10,7 +10,7 @@
 static const uint8_t OK = 0;
 static const uint8_t WARN = 1;
 static const uint8_t ERROR = 2;
-static const uint8_t STATUS_OK = 0;
+static const uint8_t CODE_OK = 0;
 
 class Module {
   public:


### PR DESCRIPTION
Reverts gordonbrander/openag_firmware_module#2.

Ugh... I did not get enough sleep. This naming change leads to confusion with status_level. Reverting.